### PR TITLE
Add support for multiple credentials

### DIFF
--- a/lib/ship_compliant/add_update_brand.rb
+++ b/lib/ship_compliant/add_update_brand.rb
@@ -37,8 +37,8 @@ module ShipCompliant
     #     ShipCompliant::AddUpdateBrand.product({
     #       # brand attributes
     #     }, update_mode: 'UpdateExisting')
-    def self.brand(brand, options = {})
-      result = ShipCompliant.client.call(:add_update_brand, {
+    def self.brand(brand, options: {}, configuration: :default)
+      result = ShipCompliant.client(configuration: configuration).call(:add_update_brand, {
         'Brand' => brand.deep_transform_keys { |key| key.to_s.camelize },
         'UpdateMode' => options.fetch(:update_mode, 'ErrorOnExisting')
       })

--- a/lib/ship_compliant/add_update_product.rb
+++ b/lib/ship_compliant/add_update_product.rb
@@ -46,20 +46,20 @@ module ShipCompliant
     #     ShipCompliant::AddUpdateProduct.product({
     #       # product attributes
     #     }, update_mode: 'UpdateExisting')
-    def self.product(product, options = {})
+    def self.product(product, options: {}, configuration: :default)
       details = {
         'Product' => ProductAttributes.new(product).to_h,
         'UpdateMode' => options.fetch(:update_mode, 'ErrorOnExisting')
       }
 
-      result = add_update_product(details)
+      result = add_update_product(details, configuration: configuration)
       AddUpdateProductResult.new(result)
     end
 
     private
 
-    def self.add_update_product(request)
-      ShipCompliant.client.call(:add_update_product, request)
+    def self.add_update_product(request, configuration:)
+      ShipCompliant.client(configuration: configuration).call(:add_update_product, request)
     end
 
   end

--- a/lib/ship_compliant/check_compliance.rb
+++ b/lib/ship_compliant/check_compliance.rb
@@ -31,9 +31,9 @@ module ShipCompliant
     #     include_sales_tax_rates: true,
     #     # ...
     #   })
-    def self.of_sales_order(data)
+    def self.of_sales_order(data, configuration: :default)
       camel_cased_keys = data.deep_transform_keys { |key| key.to_s.camelize }
-      result = ShipCompliant.client.call(:check_compliance_of_sales_order_with_address_validation, camel_cased_keys)
+      result = ShipCompliant.client(configuration: configuration).call(:check_compliance_of_sales_order_with_address_validation, camel_cased_keys)
       CheckComplianceResult.new(result)
     end
 

--- a/lib/ship_compliant/client.rb
+++ b/lib/ship_compliant/client.rb
@@ -4,36 +4,51 @@ module ShipCompliant
   end
 
   # Returns an instance of +Client+.
-  def self.client
-    self.ship_compliant_client ||= new_client_from_wsdl(configuration.wsdl)
+  def self.client(configuration: :default)
+    config = get_config_object_for_key(configuration)
+    self.ship_compliant_client ||= new_client_from_wsdl(config.wsdl,
+      configuration: config)
   end
 
   # Replaces #client with custom WSDL
   #
   #   ShipCompliant.wsdl = 'https://ws-dev.shipcompliant.com/Services/1.2/ProductService.asmx?WSDL'
-  def self.wsdl=(wsdl)
-    self.ship_compliant_client = new_client_from_wsdl(wsdl)
+  def self.set_wsdl(wsdl, configuration:)
+    self.ship_compliant_client = new_client_from_wsdl(wsdl,
+      configuration: get_config_object_for_key(configuration))
+  end
+
+  def self.get_config_object_for_key(config_key)
+    {
+      default: ShipCompliant.configuration,
+      secondary: ShipCompliant.secondary_configuration
+    }[config_key]
   end
 
   private
 
   # Creates a new client from a WSDL url.
-  def self.new_client_from_wsdl(wsdl)
-    Client.new(wsdl: wsdl, log: configuration.log, filters: %W[PartnerKey Username Password])
+  def self.new_client_from_wsdl(wsdl, configuration:)
+    client = Client.new(wsdl: wsdl, log: configuration.log,
+      filters: %W[PartnerKey Username Password])
+    client.configuration = configuration
+    client
   end
 
   class Client < Savon::Client
+    attr_accessor :configuration
+
     # "Backup" original #call from Savon::Client
     alias_method :savon_call, :call
 
     # Adds the required security credentials and formats
     # the message to match the ShipCompliant structure.
     #
-    #   ShipCompliant.client.call(:some_operation, {
+    #   ShipCompliant.client(configuration: configuration).call(:some_operation, {
     #     'SomeKey' => 'SomeValue'
     #   })
     def call(operation, locals = {})
-      locals['Security'] = ShipCompliant.configuration.credentials
+      locals['Security'] = configuration.credentials
 
       response = savon_call(operation, message: {
         'Request' => locals

--- a/lib/ship_compliant/commit_sales_order.rb
+++ b/lib/ship_compliant/commit_sales_order.rb
@@ -38,9 +38,9 @@ module ShipCompliant
     #     sales_tax_collected: 0,
     #     sales_order_key: 'ORDER-KEY'
     #   })
-    def self.call(commit_data)
+    def self.call(commit_data, configuration: :default)
       commit_data.deep_transform_keys! { |key| key.to_s.camelize }
-      result = ShipCompliant.client.call(:commit_sales_order, commit_data)
+      result = ShipCompliant.client(configuration: configuration).call(:commit_sales_order, commit_data)
       CommitSalesOrderResult.new(result)
     end
 

--- a/lib/ship_compliant/configuration.rb
+++ b/lib/ship_compliant/configuration.rb
@@ -1,14 +1,18 @@
 module ShipCompliant
   class << self
-    attr_accessor :configuration
+    attr_accessor :configuration, :secondary_configuration
   end
 
   def self.configure
-    yield(configuration)
+    yield(configuration, secondary_configuration)
   end
 
   def self.configuration
     @configuration ||= Configuration.new
+  end
+
+  def self.secondary_configuration
+    @secondary_configuration ||= Configuration.new
   end
 
   # Stores runtime configuration to authenticate user.

--- a/lib/ship_compliant/get_inventory_details.rb
+++ b/lib/ship_compliant/get_inventory_details.rb
@@ -21,9 +21,9 @@ module ShipCompliant
     #     brand_key: 'BRAND-KEY',
     #     fulfillment_location: 'WineShipping'
     #   })
-    def self.call(query = {})
+    def self.call(query: {}, configuration: :default)
       query.deep_transform_keys! { |k| k.to_s.camelize }
-      result = ShipCompliant.client.call(:get_inventory_details, query)
+      result = ShipCompliant.client(configuration: configuration).call(:get_inventory_details, query)
       GetInventoryDetailsResult.new(result)
     end
 

--- a/lib/ship_compliant/get_sales_order_extended.rb
+++ b/lib/ship_compliant/get_sales_order_extended.rb
@@ -11,8 +11,8 @@ module ShipCompliant
     # Finds a +SalesOrder+ by the +SalesOrderKey+.
     #
     # Returns an instance of ShipCompliant::GetSalesOrderExtendedResult.
-    def self.by_order_key(order_key)
-      result = ShipCompliant.client.call(:get_sales_order_extended, {
+    def self.by_order_key(order_key, configuration: :default)
+      result = ShipCompliant.client(configuration: configuration).call(:get_sales_order_extended, {
         'SalesOrderKey' => order_key
       })
 

--- a/lib/ship_compliant/search_more_sales_orders.rb
+++ b/lib/ship_compliant/search_more_sales_orders.rb
@@ -26,8 +26,8 @@ module ShipCompliant
     #
     #   orders = ShipCompliant::SearchMoreSalesOrders.paging_cookie('paging-cookie')
     #   puts orders.length #=> 100
-    def self.paging_cookie(cookie)
-      sales = ShipCompliant.client.call(:search_more_sales_orders, {
+    def self.paging_cookie(cookie, configuration: :default)
+      sales = ShipCompliant.client(configuration: configuration).call(:search_more_sales_orders, {
         'PagingCookie' => cookie
       })
 

--- a/lib/ship_compliant/search_sales_orders.rb
+++ b/lib/ship_compliant/search_sales_orders.rb
@@ -36,17 +36,17 @@ module ShipCompliant
     #   orders = ShipCompliant::SearchSalesOrders.find_by({
     #     compliance_status: 'NotCompliant' # possible values are "Compliant", "NotCompliant", or "Any". Any is default.
     #   })
-    def self.find_by(query)
+    def self.find_by(query, configuration: :default)
       order_query = OrderSearch.new(query).to_h
 
-      sales = search_sales(order_query)
+      sales = search_sales(order_query, configuration: configuration)
       SearchSalesOrdersResult.new(sales.to_hash)
     end
 
     private
     
-    def self.search_sales(order_query)
-      ShipCompliant.client.call(:search_sales_orders, order_query)
+    def self.search_sales(order_query, configuration:)
+      ShipCompliant.client(configuration: configuration).call(:search_sales_orders, order_query)
     end
 
   end

--- a/lib/ship_compliant/void_sales_order.rb
+++ b/lib/ship_compliant/void_sales_order.rb
@@ -27,15 +27,15 @@ module ShipCompliant
     # Returns an instance of ShipCompliant::VoidSalesOrderResult
     #
     #   result = ShipCompliant::VoidSalesOrder.by_order_key('OrderKey')
-    def self.by_order_key(order_key)
-      result = void_order({ 'SalesOrderKey' => order_key })
+    def self.by_order_key(order_key, configuration: :default)
+      result = void_order({ 'SalesOrderKey' => order_key }, configuration: configuration)
       VoidSalesOrderResult.new(result)
     end
 
     private
 
-    def self.void_order(request)
-      ShipCompliant.client.call(:void_sales_order, request)
+    def self.void_order(request, configuration:)
+      ShipCompliant.client(configuration: configuration).call(:void_sales_order, request)
     end
 
   end

--- a/spec/lib/ship_compliant/add_update_brand_spec.rb
+++ b/spec/lib/ship_compliant/add_update_brand_spec.rb
@@ -36,7 +36,7 @@ module ShipCompliant
           key: 'WNDFL',
           name: 'Wonderful',
           owner: { name: 'Sam' }
-        }, update_mode: 'DoWackaDo')
+        }, options: { update_mode: 'DoWackaDo'})
 
         result.should be_kind_of(AddUpdateBrandResult)
       end

--- a/spec/lib/ship_compliant/add_update_product_spec.rb
+++ b/spec/lib/ship_compliant/add_update_product_spec.rb
@@ -31,7 +31,7 @@ module ShipCompliant
         result = AddUpdateProduct.product({
           bottle_size_ml: 123,
           default_wholesale_case_price: 150
-        }, update_mode: 'DoWackaDo')
+        }, options: { update_mode: 'DoWackaDo'})
 
         result.should be_kind_of(AddUpdateProductResult)
       end

--- a/spec/lib/ship_compliant/client_spec.rb
+++ b/spec/lib/ship_compliant/client_spec.rb
@@ -12,12 +12,12 @@ module ShipCompliant
         c.wsdl = 'http://example.com'
       end
 
-      ShipCompliant.client.globals[:wsdl].should == 'http://example.com'
+      ShipCompliant.client(configuration: :default).globals[:wsdl].should == 'http://example.com'
     end
 
     it "uses log value from configuration" do
       # configuration is defined in spec_helper.rb
-      ShipCompliant.client.globals[:log].should == false
+      ShipCompliant.client(configuration: :default).globals[:log].should == false
     end
 
     context "call" do
@@ -64,7 +64,7 @@ module ShipCompliant
       it "changes the default wsdl" do
         ShipCompliant.configuration = nil
         ShipCompliant.client.globals[:wsdl].should == 'https://ws-dev.shipcompliant.com/services/1.2/coreservice.asmx?WSDL'
-        ShipCompliant.wsdl = 'http://ws.example.com?WSDL'
+        ShipCompliant.set_wsdl('http://ws.example.com?WSDL', configuration: :default)
         ShipCompliant.client.globals[:wsdl].should == 'http://ws.example.com?WSDL'
       end
     end

--- a/spec/lib/ship_compliant/configuration_spec.rb
+++ b/spec/lib/ship_compliant/configuration_spec.rb
@@ -3,12 +3,15 @@ require "spec_helper"
 module ShipCompliant
   describe Configuration do
 
+    let(:secondary_username) { 'fdsafdsafdsafdsa' }
+
     before do
       ShipCompliant.configuration = nil
-      ShipCompliant.configure do |c|
+      ShipCompliant.configure do |c, c2|
         c.partner_key = 'abc-123'
         c.username = 'bob@example.com'
         c.password = 'secret'
+        c2.username = secondary_username
       end
     end
     
@@ -16,6 +19,11 @@ module ShipCompliant
       ShipCompliant.configuration.partner_key.should == 'abc-123'
       ShipCompliant.configuration.username.should == 'bob@example.com'
       ShipCompliant.configuration.password.should == 'secret'
+    end
+
+    it "stores secondary set of credentials" do
+      expect(ShipCompliant.secondary_configuration.username)
+        .to eq(secondary_username)
     end
 
     it "creates authentication hash" do

--- a/spec/lib/ship_compliant/get_inventory_details_spec.rb
+++ b/spec/lib/ship_compliant/get_inventory_details_spec.rb
@@ -24,10 +24,10 @@ module ShipCompliant
         .with(message: message)
         .returns(File.read('spec/fixtures/void_order_success.xml'))
 
-      result = GetInventoryDetails.call(
+      result = GetInventoryDetails.call(query: {
         brand_key: 'BRAND-KEY',
         fulfillment_location: 'FULFILLMENT-LOCATION'
-      )
+      })
 
       result.should be_kind_of(GetInventoryDetailsResult)
     end


### PR DESCRIPTION
Breaks a few existing calls but tries to keep them intact for the most part.

Basically you'll just specify `ShipCompliantClassOrSomething.perform_call(...)` or `ShipCompliantClassOrSomething.perform_call(..., configuration: :default)` or `ShipCompliantClassOrSomething.perform_call(..., configuration: :secondary)`. It uses the default by default, of course. Also you do the setup like this:

``` ruby
ShipCompliant.configure do |c, c2|
  c.partner_key = 'abc-123'
  c.username = 'bob@example.com'
  c.password = 'secret'
  c.partner_key = 'abc-12345'
  c2.username = 'slob@example.com'
  c2.password = 'notsosecret'
end
```

/cc @blueapron/wine 
