### PR TITLE
Add shipment items to sc

### DIFF
--- a/lib/ship_compliant.rb
+++ b/lib/ship_compliant.rb
@@ -14,6 +14,7 @@ require "ship_compliant/address/suggested_address"
 
 require "ship_compliant/shipment"
 require "ship_compliant/package"
+require "ship_compliant/shipment_item"
 require "ship_compliant/channel_details"
 
 # SEARCH SALES ORDERS

--- a/lib/ship_compliant/shipment.rb
+++ b/lib/ship_compliant/shipment.rb
@@ -51,6 +51,12 @@ module ShipCompliant
       end
     end
 
+    def shipment_items
+      Array.wrap(shipment[:shipment_items]).map do |shipment_item|
+        ShipmentItem.new(shipment_item[:shipment_item])
+      end
+    end
+
     def ship_to
       Address.new(shipment[:ship_to])
     end

--- a/lib/ship_compliant/shipment_item.rb
+++ b/lib/ship_compliant/shipment_item.rb
@@ -1,0 +1,19 @@
+module ShipCompliant
+  class ShipmentItem < Struct.new(:shipment_item)
+    def brand_key
+      shipment_item[:brand_key]
+    end
+
+    def product_quantity
+      shipment_item[:product_quantity]
+    end
+
+    def product_key
+      shipment_item[:product_key]
+    end
+
+    def product_unit_price
+      shipment_item[:product_unit_price]
+    end
+  end
+end

--- a/lib/ship_compliant/version.rb
+++ b/lib/ship_compliant/version.rb
@@ -1,3 +1,3 @@
 module ShipCompliant
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end

--- a/spec/lib/ship_compliant/shipment_item_spec.rb
+++ b/spec/lib/ship_compliant/shipment_item_spec.rb
@@ -1,0 +1,32 @@
+require "spec_helper"
+
+module ShipCompliant
+  describe ShipmentItem do
+
+    it "gets the product_key" do
+      subject.product_key.should == 'SKU'
+    end
+
+    it "gets the brand_key" do
+      subject.brand_key.should == 'Whatever'
+    end
+
+    it "gets the product_quantity" do
+      subject.product_quantity.should == '1'
+    end
+
+    it "gets the product_unit_price" do
+      subject.product_unit_price.should == '60'
+    end
+
+    subject do
+      ShipmentItem.new(
+        product_key: 'SKU',
+        brand_key: 'Whatever',
+        product_quantity: '1',
+        product_unit_price: '60'
+      )
+    end
+
+  end
+end

--- a/spec/lib/ship_compliant/shipment_spec.rb
+++ b/spec/lib/ship_compliant/shipment_spec.rb
@@ -75,6 +75,12 @@ module ShipCompliant
       end
     end
 
+    context "shipment_items" do
+      it "gets the shipment_items" do
+        subject.shipment_items.should == [ShipmentItem.new(product_key: 'SKU')]
+      end
+    end
+
     context "ship_to" do
       it "gets the shipping address" do
         subject.ship_to.should == Address.new(country: 'US')
@@ -98,6 +104,7 @@ module ShipCompliant
         special_instructions: 'Get autograph',
 
         packages: [{ package: {tracking: 'info here'} }],
+        shipment_items: { shipment_item: { product_key: 'SKU'} },
 
         ship_to: { country: 'US' }
       })


### PR DESCRIPTION
cc @blueapron/wine 

SC failed to wrap a shipment's shipment_items in a struct like it does for its packages. This fixes that, and will bump the gem version. Maybe I'll set up a PR on the master, although it appears like SC abandoned the repo years ago.
